### PR TITLE
The params arguments was added to the purchase find method

### DIFF
--- a/src/Endpoints/Purchases.php
+++ b/src/Endpoints/Purchases.php
@@ -63,11 +63,11 @@ class Purchases extends Endpoint
         throw new \Exception("Purchase is not valid", 1);
     }
 
-    public function find($invoiceNumber)
+    public function find($invoiceNumber, $params = [])
     {
-        $response = $this->get($this->host . '/purchases', [
+        $response = $this->get($this->host . '/purchases', array_merge([
             'invoice_number' => $invoiceNumber,
-        ]);
+        ], $params));
 
         if ($response->getStatusCode() == Endpoint::HTTP_OK) {
             $data = json_decode($response->getBody());


### PR DESCRIPTION
Con la necesidad de obtener los installment de las ventas, se ha ampliado la funcionalidad de la función find, permitiéndole ahora recibir un argumento opcional llamado parms. Este nuevo argumento se utiliza para agregar parámetros adicionales al endpoint de purchase.
Adjunto captura de un proceso para dejar en evidencia que la función find no rompe si NO se le pasa el segundo parámetro y sigue su funcionamiento normal.
Tomamos como ejemplo ShipNowConnector 
Acá vemos que el funcionamiento es normal y el proceso ejecuta bien 
![Captura de pantalla 2024-05-14 151846](https://github.com/woowup/woowup-php-client-v2/assets/169811485/56d9fe99-2992-474b-8810-65646573228f)
![image](https://github.com/woowup/woowup-php-client-v2/assets/169811485/b92fa248-9cb9-4726-b790-8038fee65820)

Acá le pasamos los nuevos parametros
![image](https://github.com/woowup/woowup-php-client-v2/assets/169811485/067aa72f-b0c2-4080-855d-5bfde2a9707f)
![image](https://github.com/woowup/woowup-php-client-v2/assets/169811485/29d0a5df-1301-480b-9214-d24667e05be6)

