### PR TITLE
feat(endpoints): forward injectable http client through all endpoint constructors

### DIFF
--- a/src/Endpoints/AbandonedCarts.php
+++ b/src/Endpoints/AbandonedCarts.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
  */
 class AbandonedCarts extends Endpoint
 {
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function create(\WoowUpV2\Models\AbandonedCartModel $cart)

--- a/src/Endpoints/Banks.php
+++ b/src/Endpoints/Banks.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
  */
 class Banks extends Endpoint
 {
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function getDataFromFirstDigits(string $firstSixDigits)

--- a/src/Endpoints/Blacklist.php
+++ b/src/Endpoints/Blacklist.php
@@ -9,9 +9,9 @@ class Blacklist extends Endpoint
     const ACTION_CREATE        = 'create';
     const ACTION_DELETE_CREATE = 'delete-create';
 
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function create($file, $type)

--- a/src/Endpoints/Branches.php
+++ b/src/Endpoints/Branches.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
  */
 class Branches extends Endpoint
 {
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function update($branchName, \WoowUpV2\Models\BranchModel $branch)

--- a/src/Endpoints/CustomAttributes.php
+++ b/src/Endpoints/CustomAttributes.php
@@ -10,9 +10,9 @@ class CustomAttributes extends Endpoint
 		'products'		=> 'product-custom-attributes',
 	];
 
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
 

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -30,6 +30,12 @@ class Endpoint
     protected $apikey;
     protected $http;
 
+    private static $requestCounts = [];
+
+    public static function getRequestCount(): int { return array_sum(self::$requestCounts); }
+    public static function getRequestCounts(): array { return self::$requestCounts; }
+    public static function resetRequestCount(): void { self::$requestCounts = []; }
+
     public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
         $this->host   = $host;
@@ -171,6 +177,8 @@ class Endpoint
 
     protected function request($verb, $url, $params)
     {
+        $class = static::class;
+        self::$requestCounts[$class] = (self::$requestCounts[$class] ?? 0) + 1;
         $attempts = 0;
 
         while ($attempts < self::MAX_ATTEMPTS) {

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -30,11 +30,15 @@ class Endpoint
     protected $apikey;
     protected $http;
 
-    private static $requestCounts = [];
+    private static $requestCounts  = [];
+    private static $throttleCounts = [];
 
-    public static function getRequestCount(): int { return array_sum(self::$requestCounts); }
+    public static function getRequestCount(): int   { return array_sum(self::$requestCounts); }
     public static function getRequestCounts(): array { return self::$requestCounts; }
     public static function resetRequestCount(): void { self::$requestCounts = []; }
+
+    public static function getThrottleCounts(): array { return self::$throttleCounts; }
+    public static function resetThrottleCount(): void  { self::$throttleCounts = []; }
 
     public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
@@ -186,6 +190,10 @@ class Endpoint
                 return $this->http->request($verb, $url, $params);
             } catch (\GuzzleHttp\Exception\RequestException $e) {
                 $this->assertRetryable($e, $attempts);
+
+                if ($e->hasResponse() && $e->getResponse()->getStatusCode() === self::HTTP_TOO_MANY_REQUEST) {
+                    self::$throttleCounts[$class] = (self::$throttleCounts[$class] ?? 0) + 1;
+                }
 
                 sleep($this->calculateSleep($e->getResponse(), $attempts));
                 $attempts++;

--- a/src/Endpoints/Events.php
+++ b/src/Endpoints/Events.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
  */
 class Events extends Endpoint
 {
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function create(\WoowUpV2\Models\EventModel $event)

--- a/src/Endpoints/Products.php
+++ b/src/Endpoints/Products.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
  */
 class Products extends Endpoint
 {
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function exist($sku)

--- a/src/Endpoints/Purchases.php
+++ b/src/Endpoints/Purchases.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
 */
 class Purchases extends Endpoint
 {
-    function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function bulkCreate($purchases)

--- a/src/Endpoints/Segments.php
+++ b/src/Endpoints/Segments.php
@@ -3,9 +3,9 @@ namespace WoowUpV2\Endpoints;
 
 class Segments extends Endpoint
 {
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function find($segmentId, $params = [])

--- a/src/Endpoints/Stats.php
+++ b/src/Endpoints/Stats.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
  */
 class Stats extends Endpoint
 {
-	public function __construct($host, $apikey)
+	public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
 	{
-		parent::__construct($host, $apikey);
+		parent::__construct($host, $apikey, $http);
 	}
 
 	public function create($stats)

--- a/src/Endpoints/UserEvents.php
+++ b/src/Endpoints/UserEvents.php
@@ -6,9 +6,9 @@ namespace WoowUpV2\Endpoints;
  */
 class UserEvents extends Endpoint
 {
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function create(\WoowUpV2\Models\UserEventModel $event)

--- a/src/Endpoints/Users.php
+++ b/src/Endpoints/Users.php
@@ -13,9 +13,9 @@ class Users extends Endpoint
         'telephone'   => ''
     ];
 
-    public function __construct($host, $apikey)
+    public function __construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)
     {
-        parent::__construct($host, $apikey);
+        parent::__construct($host, $apikey, $http);
     }
 
     public function update(\WoowUpV2\Models\UserModel $user)


### PR DESCRIPTION
## Por qué se hace este PR

En `woowup/connectors` se implementó un contador de requests HTTP hacia la API de WoowUp, visible en el summary del flag `-v` de los comandos. El contador vive directamente en `Endpoint::request()` de este repo — sin necesidad de inyectar ningún cliente custom desde connectors.

El injectable `$http` es un **bonus separado**: no es requerido para el contador, pero habilita inyectar un cliente mock en tests sin necesidad de Reflection, y deja la puerta abierta para un futuro cliente dry-run (simulación de writes sin llamadas reales).

---

## Cambios

### 1. Static request counter en `Endpoint`

```php
private static $requestCounts = [];

public static function getRequestCount(): int  { return array_sum(self::$requestCounts); }
public static function getRequestCounts(): array { return self::$requestCounts; }
public static function resetRequestCount(): void { self::$requestCounts = []; }

protected function request($verb, $url, $params)r
{
    $class = static::class;
    self::$requestCounts[$class] = (self::$requestCounts[$class] ?? 0) + 1;
    // ... lógica existente
}
```

Cada llamada HTTP incrementa el contador keyed por `static::class` (late static binding), lo que permite ver el desglose por endpoint. El consumidor llama `Endpoint::getRequestCounts()` para leer y `resetRequestCount()` para reiniciar entre cuentas.

### 2. Contador de throttling (429)

```php
private static $throttleCounts = [];

public static function getThrottleCounts(): array { return self::$throttleCounts; }
public static function resetThrottleCount(): void  { self::$throttleCounts = []; }

// en request(), dentro del catch, después de assertRetryable():
if ($e->hasResponse() && $e->getResponse()->getStatusCode() === self::HTTP_TOO_MANY_REQUEST) {
    self::$throttleCounts[$class] = (self::$throttleCounts[$class] ?? 0) + 1;
}
```

Solo cuenta 429s — no 502 ni 503. Se incrementa por cada retry que consume un rate limit real. Visible en el summary de `-v` de `woowup/connectors` como `"throttled": N` (solo si N > 0).

### 3. `$http` inyectable en todos los endpoints (bonus, no requerido para el contador)

Todos los constructores pasan de `__construct($host, $apikey)` a
`__construct($host, $apikey, \GuzzleHttp\ClientInterface $http = null)` y forwardean
al `parent::__construct()`. `Client::__construct()` ya aceptaba y pasaba `$http` — ahora
efectivamente llega a cada endpoint.

**Archivos:** `AbandonedCarts`, `Banks`, `Blacklist`, `Branches`, `CustomAttributes`,
`Events`, `Products`, `Purchases`, `Segments`, `Stats`, `UserEvents`, `Users`.
(`Account` y `Endpoint` ya tenían la firma correcta.)

---

## Compatibilidad

**100% backward compatible en los tres cambios:**

- Los contadores (request y throttle) son código nuevo que no toca lógica existente.
- `$http = null` es opcional en todos los niveles. `new Products($host, $apikey)` funciona igual que antes.
- Sin `$http`, se crea el `GuzzleHttp\Client` por defecto con los mismos timeouts.
- PHP 7.4+ (`TypeHint $param = null` válido desde PHP 5.x).
