### PR TITLE
feat(custom-attributes): support rename via optional `$oldName` in `updateAttributeDefinition`

### DIFF
--- a/src/Endpoints/CustomAttributes.php
+++ b/src/Endpoints/CustomAttributes.php
@@ -39,6 +39,13 @@ class CustomAttributes extends Endpoint
 
     }
 
+    public function renameAttributeDefinition(string $oldName, $data, string $entity): bool
+    {
+        $response = $this->put($this->host . '/account/' . self::ENTITIES[$entity] . '/' . $oldName, $data);
+
+        return $response->getStatusCode() == Endpoint::HTTP_OK || $response->getStatusCode() == Endpoint::HTTP_CREATED;
+    }
+
     public function create(\WoowUpV2\Models\CustomAttributeModel $customAttribute, $entity)
     {
         if ($customAttribute->validate()) {

--- a/src/Endpoints/CustomAttributes.php
+++ b/src/Endpoints/CustomAttributes.php
@@ -31,19 +31,12 @@ class CustomAttributes extends Endpoint
         return false;
     }
 
-    public function updateAttributeDefinition($data, $entity)
+    public function updateAttributeDefinition($data, $entity, string $oldName = null)
     {
-    	$response = $this->put($this->host . '/account/' . self::ENTITIES[$entity] . '/' . $data->name, $data);
+        $name = $oldName ?? $data->name;
+    	$response = $this->put($this->host . '/account/' . self::ENTITIES[$entity] . '/' . $name, $data);
 
     	return $response->getStatusCode() == Endpoint::HTTP_OK || $response->getStatusCode() == Endpoint::HTTP_CREATED;
-
-    }
-
-    public function renameAttributeDefinition(string $oldName, $data, string $entity): bool
-    {
-        $response = $this->put($this->host . '/account/' . self::ENTITIES[$entity] . '/' . $oldName, $data);
-
-        return $response->getStatusCode() == Endpoint::HTTP_OK || $response->getStatusCode() == Endpoint::HTTP_CREATED;
     }
 
     public function create(\WoowUpV2\Models\CustomAttributeModel $customAttribute, $entity)


### PR DESCRIPTION
## Qué cambia

`updateAttributeDefinition($data, $entity)` usaba `$data->name` para construir la URL del PUT:

```
PUT /account/product-custom-attributes/{$data->name}
```

Esto imposibilitaba renombrar una definición: si el `name` en el body era el nombre nuevo, la URL también usaba el nombre nuevo — y WoowUp no encontraba la definición existente.

Se agrega `$oldName = null` como tercer parámetro opcional. Cuando se pasa, se usa en la URL en lugar de `$data->name`:

```
PUT /account/product-custom-attributes/{$oldName}   ← nombre actual en WoowUp
Body: { "name": "nuevo_nombre_canonico", ... }       ← rename
```

Backwards compatible: todos los call sites existentes sin `$oldName` siguen funcionando igual.

## Por qué

Necesario para el fix de custom attributes duplicados en VTEX. Cuando WoowUp tiene una definición con nombre legacy no-normalizado (ej: `Tipo_de_Producto`), el handler ahora la renombra en-place a la versión canónica (`tipo_de_producto`) en lugar de crear una definición nueva duplicada.

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `src/Endpoints/CustomAttributes.php` | `$oldName = null` opcional en `updateAttributeDefinition`, usa `$oldName ?? $data->name` para la URL |
