### PR TITLE
feat(product-model): normalize custom attribute keys to prevent duplicates in WoowUp

### DIFF
--- a/src/DataQuality/CustomAttributeCleanser.php
+++ b/src/DataQuality/CustomAttributeCleanser.php
@@ -20,7 +20,8 @@ class CustomAttributeCleanser
 	 */
 	public function normalizeName(string $name): string
 	{
-		$noAccents = preg_replace('/\p{Mn}/u', '', \Normalizer::normalize($name, \Normalizer::FORM_D));
+		$normalized = \Normalizer::normalize($name, \Normalizer::FORM_D) ?: $name;
+		$noAccents  = preg_replace('/\p{Mn}/u', '', $normalized) ?? $name;
 		return str_replace([' ', '-'], '_', mb_strtolower($noAccents));
 	}
 

--- a/src/DataQuality/CustomAttributeCleanser.php
+++ b/src/DataQuality/CustomAttributeCleanser.php
@@ -20,6 +20,7 @@ class CustomAttributeCleanser
 	 */
 	public function normalizeName(string $name): string
 	{
+		$name       = trim($name);
 		$normalized = \Normalizer::normalize($name, \Normalizer::FORM_D) ?: $name;
 		$noAccents  = preg_replace('/\p{Mn}/u', '', $normalized) ?? $name;
 		return str_replace([' ', '-'], '_', mb_strtolower($noAccents));
@@ -38,7 +39,11 @@ class CustomAttributeCleanser
 	{
 		$result = [];
 		foreach ($attributes as $name => $value) {
-			$result[$this->normalizeName((string) $name)] = $value;
+			$trimmed = trim((string) $name);
+			if ($trimmed === '') {
+				continue;
+			}
+			$result[$this->normalizeName($trimmed)] = $value;
 		}
 		return $result;
 	}

--- a/src/Models/ProductModel.php
+++ b/src/Models/ProductModel.php
@@ -386,11 +386,15 @@ class ProductModel implements \JsonSerializable
      */
     public function addCustomAttribute($key, $value)
     {
-        if (!empty($key)) {
+        if (!empty(trim((string) $key))) {
+            $normalizedKey = $this->cleanser->customAttributes->normalizeName((string) $key);
+            if ($normalizedKey === '') {
+                trigger_error("Not valid key for custom_attribute after normalization", E_USER_WARNING);
+                return $this;
+            }
             if (!isset($this->custom_attributes)) {
                 $this->custom_attributes = new \stdClass();
             }
-            $normalizedKey = $this->cleanser->customAttributes->normalizeName((string) $key);
             $this->custom_attributes->{$normalizedKey} = $value;
         } else {
             trigger_error("Not valid key for custom_attribute", E_USER_WARNING);

--- a/src/Models/ProductModel.php
+++ b/src/Models/ProductModel.php
@@ -390,7 +390,8 @@ class ProductModel implements \JsonSerializable
             if (!isset($this->custom_attributes)) {
                 $this->custom_attributes = new \stdClass();
             }
-            $this->custom_attributes->{$key} = $value;
+            $normalizedKey = $this->cleanser->customAttributes->normalizeName((string) $key);
+            $this->custom_attributes->{$normalizedKey} = $value;
         } else {
             trigger_error("Not valid key for custom_attribute", E_USER_WARNING);
         }

--- a/src/Models/ProductModel.php
+++ b/src/Models/ProductModel.php
@@ -386,8 +386,9 @@ class ProductModel implements \JsonSerializable
      */
     public function addCustomAttribute($key, $value)
     {
-        if (!empty(trim((string) $key))) {
-            $normalizedKey = $this->cleanser->customAttributes->normalizeName((string) $key);
+        $trimmedKey = trim((string) $key);
+        if (!empty($trimmedKey)) {
+            $normalizedKey = $this->cleanser->customAttributes->normalizeName($trimmedKey);
             if ($normalizedKey === '') {
                 trigger_error("Not valid key for custom_attribute after normalization", E_USER_WARNING);
                 return $this;


### PR DESCRIPTION
## Qué hace este PR

Normaliza automáticamente los nombres de atributos personalizados de producto al setearlos en `ProductModel`, evitando que WoowUp cree definiciones duplicadas cuando el caller pasa nombres con mayúsculas, acentos o guiones.

## Por qué era necesario

WoowUp normaliza los nombres al crear definiciones vía la API de definiciones (`POST /account/product-custom-attributes`), pero **no** al recibir un producto con `custom_attributes` embebidos (`POST /apiv3/products`). En ese segundo caso, WoowUp crea la definición con el nombre exactamente como llega.

Entonces si el caller seteaba `Colecciones` en el modelo, WoowUp creaba una definición `Colecciones`. Si en otro contexto ya existía `colecciones` (la forma normalizada), terminaban coexistiendo dos definiciones separadas que en realidad representan lo mismo.

## Qué se cambió

### `CustomAttributeCleanser` (nuevo)

Nuevo cleanser en `DataQuality/` con dos métodos:

- `normalizeName(string $name): string` — aplica `trim + deleteAccents + mb_strtolower + espacios/guiones → underscore`, equivalente al `bugSlugify` del servidor de WoowUp
- `normalizeKeys(array $attributes): array` — normaliza todas las keys de un mapa de atributos sin tocar los valores

Registrado en `DataCleanser` como `$cleanser->customAttributes`.

### `ProductModel::addCustomAttribute()`

Aplica `normalizeName()` sobre la key antes de guardarla. Tanto `addCustomAttribute()` directo como `setCustomAttributes()` (que delega en él) normalizan automáticamente.

## Antes / después

**Antes** — el nombre llegaba a WoowUp exactamente como lo pasó el caller:

```json
POST /apiv3/products
{
  "sku": "ABC123",
  "custom_attributes": {
    "Colecciones": "Verano",
    "TALLE": "M",
    "nombre-complementario": "Remera básica"
  }
}
```

WoowUp creaba definiciones `Colecciones`, `TALLE`, `nombre-complementario` — distintas de las ya existentes `colecciones`, `talle`, `nombre_complementario`.

---

**Después** — `ProductModel` normaliza las keys antes de serializar:

```json
POST /apiv3/products
{
  "sku": "ABC123",
  "custom_attributes": {
    "colecciones": "Verano",
    "talle": "M",
    "nombre_complementario": "Remera básica"
  }
}
```

WoowUp encuentra las definiciones existentes y no crea duplicados.

---

**Ejemplos de normalización:**

| Input caller         | Key en el JSON |
|----------------------|----------------|
| `Colecciones`        | `colecciones`  |
| `Colección`          | `coleccion`    |
| `TALLE`              | `talle`        |
| `Baño`               | `bano`         |
| `nombre-complementario` | `nombre_complementario` |
| `Tipo de Prenda`     | `tipo_de_prenda` |
| `  Baño  `           | `bano`         |
